### PR TITLE
Ensure that inactive users can't log in

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -36,7 +36,7 @@ INSTALLED_APPS = [
     'oauth2_provider',
 
     'sso.user',
-    'sso.samlauth'
+    'sso.samlauth',
 ]
 
 MIDDLEWARE = [
@@ -123,7 +123,7 @@ SAML_USER_MODEL = 'user.user'
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
-    'djangosaml2.backends.Saml2Backend',
+    'sso.samlauth.backends.Saml2Backend',
 )
 
 SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'email'

--- a/sso/samlauth/backends.py
+++ b/sso/samlauth/backends.py
@@ -1,0 +1,12 @@
+from djangosaml2.backends import Saml2Backend as DjangoSaml2Backend
+
+
+class Saml2Backend(DjangoSaml2Backend):
+    def authenticate(self, **kwargs):
+        """
+        Extends the default djangosaml2 Saml2Backend checking if the
+        user can authenticate as well (e.g. .is_active == True).
+        """
+        user = super().authenticate(**kwargs)
+        if user and self.user_can_authenticate(user):
+            return user


### PR DESCRIPTION
This extends the Django SAML Backend and stops inactive users from logging in.