### PR TITLE
Add /user/me/ API endpoint

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import include, url
+
+from sso.user import urls as user_urls
+
+urlpatterns = [
+    url(r'^user/', include((user_urls, 'user'), namespace='user')),
+]

--- a/config/settings.py
+++ b/config/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'djangosaml2',
     'oauth2_provider',
+    'rest_framework',
 
     'sso.user',
     'sso.samlauth'
@@ -206,4 +207,16 @@ SAML_CONFIG = {
 
 SAML_ATTRIBUTE_MAPPING = {
     'email': ('email', ),
+}
+
+
+# DRF
+REST_FRAMEWORK = {
+    'UNAUTHENTICATED_USER': None,
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication'
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated'
+    ],
 }

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,8 +1,12 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from . import api_urls
+
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^saml2/', include('sso.samlauth.urls')),
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+
+    url(r'^api/v1/', include((api_urls, 'api'), namespace='api-v1')),
 ]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client():
+    """Pytest fixture for Django REST framework ApiClient."""
+    return APIClient()

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,8 @@ djangosaml2
 
 django-oauth-toolkit
 
+djangorestframework
+
 flake8
 flake8-blind-except
 flake8-debugger
@@ -22,4 +24,5 @@ pytest-sugar
 pytest-mock
 pytest-env
 pytest-cov
+factory-boy
 freezegun

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,10 @@ defusedxml==0.4.1         # via djangosaml2
 django-environ==0.4.3
 django-oauth-toolkit==1.0.0
 django==1.11.2
+djangorestframework==3.6.3
 djangosaml2==0.16.0
+factory-boy==2.8.1
+faker==0.7.17             # via factory-boy
 flake8-blind-except==0.1.1
 flake8-debugger==1.4.0
 flake8-import-order==0.12
@@ -44,11 +47,11 @@ pytest-env==0.6.2
 pytest-mock==1.6.0
 pytest-sugar==0.8.0
 pytest==3.1.2
-python-dateutil==2.6.0    # via freezegun, pysaml2
+python-dateutil==2.6.0    # via faker, freezegun, pysaml2
 pytz==2017.2              # via django, pysaml2
 repoze.who==2.3           # via pysaml2
 requests==2.18.1          # via django-oauth-toolkit, pysaml2
-six==1.10.0               # via cryptography, django-environ, freezegun, paste, pyopenssl, pysaml2, python-dateutil
+six==1.10.0               # via cryptography, django-environ, faker, freezegun, paste, pyopenssl, pysaml2, python-dateutil
 termcolor==1.1.0          # via pytest-sugar
 urllib3==1.21.1           # via requests
 webob==1.7.2              # via repoze.who

--- a/sso/tests/factories/oauth.py
+++ b/sso/tests/factories/oauth.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+import factory
+from django.utils import timezone
+from oauth2_provider.models import AccessToken, Application
+
+from .user import UserFactory
+
+
+class ApplicationFactory(factory.django.DjangoModelFactory):
+    client_type = Application.CLIENT_CONFIDENTIAL
+    authorization_grant_type = Application.GRANT_AUTHORIZATION_CODE
+    skip_authorization = True
+    name = 'Test oauth app'
+
+    class Meta:
+        model = Application
+
+
+class AccessTokenFactory(factory.django.DjangoModelFactory):
+    application = factory.SubFactory(ApplicationFactory)
+    token = factory.Sequence(lambda n: f'token{n+1}')
+    user = factory.SubFactory(UserFactory)
+    expires = timezone.now() + timedelta(days=1)
+    scope = 'read'
+
+    class Meta:
+        model = AccessToken

--- a/sso/tests/factories/user.py
+++ b/sso/tests/factories/user.py
@@ -1,0 +1,15 @@
+import factory
+
+
+class GroupFactory(factory.django.DjangoModelFactory):
+    name = factory.Sequence(lambda n: f'Group {n+1}')
+
+    class Meta:
+        model = 'auth.Group'
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    email = factory.Sequence(lambda n: f'user{n+1}@example.com')
+
+    class Meta:
+        model = 'user.User'

--- a/sso/tests/test_auth_flow.py
+++ b/sso/tests/test_auth_flow.py
@@ -8,10 +8,12 @@ import pytest
 from django.conf import settings
 from django.urls import reverse_lazy
 from freezegun import freeze_time
-from oauth2_provider.models import Application
 from saml2.sigver import SignatureError
 
 from sso.user.models import User
+
+from .factories.oauth import ApplicationFactory
+from .factories.user import UserFactory
 
 
 @lru_cache()
@@ -48,12 +50,8 @@ def create_oauth_application():
         oauth params as dict for the authorize request
     )
     """
-    application, _ = Application.objects.get_or_create(
-        client_type=Application.CLIENT_CONFIDENTIAL,
-        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-        skip_authorization=True,
-        redirect_uris=OAUTH_REDIRECT_URL,
-        name='Test oauth app'
+    application = ApplicationFactory(
+        redirect_uris=OAUTH_REDIRECT_URL
     )
 
     oauth_params = {
@@ -170,7 +168,7 @@ class TestSAMLLogin:
 
 class TestOAuthToken:
     def _log_user_in(self, client):
-        User.objects.create(email='user1@example.com')
+        UserFactory(email='user1@example.com')
         session_info = {
             'ava': {
                 'email': ['user1@example.com']

--- a/sso/tests/test_user_api.py
+++ b/sso/tests/test_user_api.py
@@ -1,0 +1,75 @@
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse_lazy
+from django.utils import timezone
+
+from .factories.oauth import AccessTokenFactory
+from .factories.user import GroupFactory, UserFactory
+
+pytestmark = [
+    pytest.mark.django_db
+]
+
+
+def get_oauth_token(expires=None):
+    user = UserFactory(email='user1@example.com')
+    user.groups.add(GroupFactory.create_batch(2)[1])  # create 2 groups but only assign the 2nd
+
+    access_token = AccessTokenFactory(
+        user=user,
+        expires=expires or (timezone.now() + timedelta(days=1))
+    )
+
+    return access_token.token
+
+
+class TestAPIGetUserMe:
+    GET_USER_ME_URL = reverse_lazy('api-v1:user:me')
+
+    def test_with_valid_token(self, api_client):
+        """
+        Test that with a valid token you can get the details of the logged in user.
+        """
+        token = get_oauth_token()
+
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        response = api_client.get(self.GET_USER_ME_URL)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'email': 'user1@example.com',
+            'groups': [{
+                'name': 'Group 2'
+            }]
+        }
+
+    def test_fails_with_invalid_token(self, api_client):
+        """
+        Test that with a invalid token you cannot get the details of the logged in user.
+        """
+        get_oauth_token()
+
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer invalid')
+        response = api_client.get(self.GET_USER_ME_URL)
+
+        assert response.status_code == 401
+        assert response.json() == {
+            'detail': 'Authentication credentials were not provided.'
+        }
+
+    def test_fails_with_expired_token(self, api_client):
+        """
+        Test that with an expired token you cannot get the details of the logged in user.
+        """
+        token = get_oauth_token(
+            expires=timezone.now() - timedelta(minutes=1)
+        )
+
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        response = api_client.get(self.GET_USER_ME_URL)
+
+        assert response.status_code == 401
+        assert response.json() == {
+            'detail': 'Authentication credentials were not provided.'
+        }

--- a/sso/user/admin.py
+++ b/sso/user/admin.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+from .models import User
+
+
+@admin.register(User)
+class UserAdmin(admin.ModelAdmin):
+    search_fields = ('email', )
+    fields = ('email', 'password', 'groups', 'is_superuser', 'date_joined', 'last_login')
+    readonly_fields = ('email', 'password', 'date_joined', 'last_login')
+    list_display = ('email', 'is_superuser', 'last_login')
+
+    def has_add_permission(self, request):
+        return False

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import Group
+from rest_framework import serializers
+
+from .models import User
+
+
+class GroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = ('name',)
+
+
+class UserSerializer(serializers.ModelSerializer):
+    groups = GroupSerializer(many=True)
+
+    class Meta:
+        model = User
+
+        fields = (
+            'email',
+            'groups'
+        )

--- a/sso/user/urls.py
+++ b/sso/user/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import url
+
+from .views import UserRetrieveViewSet
+
+urlpatterns = [
+    url(
+        r'^me/$',
+        UserRetrieveViewSet.as_view({
+            'get': 'retrieve'
+        }),
+        name='me'
+    ),
+]

--- a/sso/user/views.py
+++ b/sso/user/views.py
@@ -1,0 +1,11 @@
+from rest_framework import mixins, permissions, viewsets
+
+from .serializers import UserSerializer
+
+
+class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = UserSerializer
+
+    def get_object(self):
+        return self.request.user


### PR DESCRIPTION
This:
- starts using factory boys in tests
- adds DRF
- adds ability to change users via the django admin
- adds the endpoint `/api/v1/user/me/` which returns:
```
{
  'email': 'user1@example.com',
  'groups': [{
    'name': 'Group name'
  }]
}
```

New users cannot be added and email and password cannot be changed using the django admin, superusers can only assign groups and change the superuser flag.