### PR TITLE
Change SAML mapping and add default loggedin view

### DIFF
--- a/config/saml/prod/attribute_maps/__init__.py
+++ b/config/saml/prod/attribute_maps/__init__.py
@@ -2,13 +2,13 @@
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'fro': {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'emailaddress',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'email',
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'givenname',
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'surname',
         'http://schemas.xmlsoap.org/claims/Group': 'group',
     },
     'to': {
-        'emailaddress': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+        'email': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
         'givenname': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
         'surname': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
         'group': 'http://schemas.xmlsoap.org/claims/Group',

--- a/config/saml/staging/attribute_maps/__init__.py
+++ b/config/saml/staging/attribute_maps/__init__.py
@@ -2,13 +2,13 @@
 MAP = {
     'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
     'fro': {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'emailaddress',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'email',
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'givenname',
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'surname',
         'http://schemas.xmlsoap.org/claims/Group': 'group',
     },
     'to': {
-        'emailaddress': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+        'email': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
         'givenname': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
         'surname': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
         'group': 'http://schemas.xmlsoap.org/claims/Group',

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,6 +4,7 @@ import shutil
 import environ
 import saml2
 import saml2.saml
+from django.urls import reverse_lazy
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -118,6 +119,7 @@ STATIC_URL = '/static/'
 AUTH_USER_MODEL = 'user.user'
 LOGIN_URL = 'saml2_login'
 LOGOUT_REDIRECT_URL = 'saml2_login'
+LOGIN_REDIRECT_URL = reverse_lazy('saml2_loggedin')
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 SAML_USER_MODEL = 'user.user'

--- a/sso/samlauth/urls.py
+++ b/sso/samlauth/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     url(r'^logout/$', djangosaml2_views.logout, name='saml2_logout'),
     url(r'^ls/post/$', djangosaml2_views.logout_service_post, name='saml2_ls_post'),
     url(r'^metadata/$', djangosaml2_views.metadata, name='saml2_metadata'),
+    url(r'^logged-in/$', views.loggedin, name='saml2_loggedin'),
 ]

--- a/sso/samlauth/views.py
+++ b/sso/samlauth/views.py
@@ -2,6 +2,7 @@ import base64
 import logging
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.encoding import force_bytes
@@ -170,3 +171,11 @@ def login(request,
     oq_cache = OutstandingQueriesCache(request.session)
     oq_cache.set(session_id, came_from)
     return http_response
+
+
+@login_required
+def loggedin(request):
+    """
+    Fallback view after logging in if no redirect url is specified.
+    """
+    return HttpResponse('You are logged in')


### PR DESCRIPTION
This:

1. changes the SAML attribute mapping from `emailaddress` to
`email` to match the django field.

2. adds a simple default view to fall back to when no redirect
url is specified after a successful login.