### PR TITLE
Add datahub scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config/saml/prod/*.crt
 
 *.iml
 .idea
+.DS_Store

--- a/config/settings.py
+++ b/config/settings.py
@@ -231,7 +231,8 @@ OAUTH2_PROVIDER = {
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',
-        'introspection': 'introspect scope'
+        'introspection': 'introspect scope',
+        'data-hub:internal-front-end': 'A datahub specific scope'
     }
 }
 


### PR DESCRIPTION
Datahub requires a custom OAuth2 scope to differentiate between front and backend access.

Ideally we wouldn't modify this codebase for individual apps, but it is a one off case. If more applications require custom scopes we can look at implementing a DOT scope model backend.