### PR TITLE
Admin ip restriction

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,6 +16,7 @@ if os.path.exists(ENV_FILE):
     environ.Env.read_env(ENV_FILE)
 env = environ.Env(
     DEBUG=(bool, False),
+    RESTRICT_ADMIN_BY_IPS=(bool, False),
 )
 
 SECRET_KEY = env('SECRET_KEY')
@@ -53,6 +54,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'sso.core.middleware.NeverCacheMiddleware',
+    'ip_restriction.IpWhitelister',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -267,3 +269,8 @@ LOGGING = {
         'level': 'WARN'
     }
 }
+
+# admin ip restriction
+
+RESTRICT_ADMIN_BY_IPS = env('RESTRICT_ADMIN_BY_IPS')
+

--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ waitress
 whitenoise
 dj-database-url
 django-axes
+-e git+https://github.com/uktrade/dit-ip@v1.1.0#egg=django-ip-restriction

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+-e git+https://github.com/uktrade/dit-ip@v1.1.0#egg=django-ip-restriction
 asn1crypto==0.22.0        # via cryptography
 certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography

--- a/sso/oauth2/migrations/0001_initial.py
+++ b/sso/oauth2/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('skip_authorization', models.BooleanField(default=False)),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('updated', models.DateTimeField(auto_now=True)),
-                ('default_access_allowed', models.BooleanField(default=False, help_text='Allow all authenticated users to access this application', verbose_name='default access')),
+                ('default_access_allowed', models.BooleanField(default=False, help_text='Allow all authenticated users to access this application', verbose_name='default access allowed')),
                 ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='oauth2_application', to='user.User')),
             ],
             options={


### PR DESCRIPTION
Lock down the admin using django-ip-restriction.

Usage:
Set the following env vars: 
 
ALLOWED_ADMIN_IPS="1.1.1.1,2.2.2.2,3.3.3.3"  
RESTRICT_ADMIN_BY_IPS=True