### PR TITLE
Allow user's to be created and editted via admin

### DIFF
--- a/sso/user/admin.py
+++ b/sso/user/admin.py
@@ -6,12 +6,10 @@ from .models import User
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     search_fields = ('email', )
-    fields = ('email', 'is_superuser', 'date_joined', 'last_login', 'permitted_applications')
-    readonly_fields = ('email', 'password', 'date_joined', 'last_login')
+    fields = ('email', 'first_name', 'last_name',  'is_superuser', 'date_joined', 'last_login', 'permitted_applications')
+    readonly_fields = ('date_joined', 'last_login')
     list_display = ('email', 'is_superuser', 'last_login', 'permitted_apps')
 
     def permitted_apps(self, obj):
         return ', '.join(f.name for f in obj.permitted_applications.all())
 
-    def has_add_permission(self, request):
-        return False


### PR DESCRIPTION
There's a need for users to be pre-created and given relevant permissions. This will mainly happen as a bulk import, but the live services team need the ability to do this via the admin for small numbers of users.  Therefore I've changed the user model so that admins can add and edit users.