### PR TITLE
Ensure emails are lower cased

### DIFF
--- a/sso/tests/test_user.py
+++ b/sso/tests/test_user.py
@@ -60,6 +60,23 @@ class TestUserManager:
         with pytest.raises(ValueError):
             User.objects.create_superuser(email='', password='password')
 
+    @pytest.mark.django_db
+    def test_user_emails_are_lower_cased(self):
+        """
+        Test that `save()` lower cases emails
+        """
+        assert User.objects.count() == 0
+
+        email = 'ITATest1@example.com'
+
+        user = User.objects.create(
+            email=email,
+            first_name='',
+            last_name=''
+        )
+
+        assert user.email == email.lower()
+
 
 class TestUser:
     def test_is_staff_as_is_superuser(self):

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -53,6 +53,13 @@ class User(AbstractBaseUser, PermissionsMixin):
     def is_staff(self):
         return self.is_superuser
 
+    def save(self, *args, **kwargs):
+        """
+        Ensure that emails are lower cased
+        """
+        self.email = self.email.lower()
+        return super().save(*args, **kwargs)
+
     def get_full_name(self):
         """
         Django method that must be implemented


### PR DESCRIPTION
This PR makes all emails lower cased, which will solve problems with pre-creating emails as IdP seem to insistently provide either all lowercased or capitalised email addresses.

