### PR TITLE
Add an access denied page

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-
+from django.views.generic.base import TemplateView
 
 from sso.oauth2.views import CustomAuthorizationView
 
@@ -16,6 +16,8 @@ urlpatterns = [
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
     url(r'^api/v1/', include((api_urls, 'api'), namespace='api-v1')),
+
+    url(r'^access-denied/$', TemplateView.as_view(template_name='sso/access-denied.html'), name='access-denied')
 ]
 
 if getattr(settings, 'LOCAL_AUTH_PAGE'):

--- a/sso/oauth2/views.py
+++ b/sso/oauth2/views.py
@@ -5,6 +5,7 @@ from django.shortcuts import redirect
 from oauth2_provider.exceptions import OAuthToolkitError
 from oauth2_provider.models import get_application_model
 from oauth2_provider.scopes import get_scopes_backend
+from oauthlib.oauth2.rfc6749.errors import AccessDeniedError
 
 from oauth2_provider.views.base import AuthorizationView
 
@@ -52,4 +53,7 @@ class CustomAuthorizationView(AuthorizationView):
             return redirect(uri)
 
         except OAuthToolkitError as error:
-            return self.error_response(error)
+            if isinstance(error.oauthlib_error, AccessDeniedError):
+                return redirect('access-denied')
+            else:
+                return self.error_response(error)

--- a/sso/templates/sso/access-denied.html
+++ b/sso/templates/sso/access-denied.html
@@ -2,17 +2,10 @@
 
 {% block inner_content %}
 
-Content for permissions error page
-
-Access denied page
-
-You don’t have permission to access this
-
-If you think you should have access or need to sign up to a DIT system then get in touch.
-Email login.support@uktrade.zendesk.com and put the service you want to access in the subject line, and put your team and a short description of the issue in the email.
-
-Digital Workspace
-Data Hub
-MI Dashboards
+<div class="container">
+    <h1>You don’t have permission to access this application</h1>
+    <p>If you think you should have access or need to sign up to a DIT system then get in touch.</p>
+    <p>Email <a href="mailto:login.support@uktrade.zendesk.com">login.support@uktrade.zendesk.com</a> and put the service you want to access in the subject line, and put your team and a short description of the issue in the email.</p>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
If a user authenticates via the IdP but does not have permissions to access the application, we present an access denied page on the auth broker.

TODOs: 
Add some tests
Get page signed off by FED