### PR TITLE
Adjust session length

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -125,7 +125,6 @@ AUTH_USER_MODEL = 'user.user'
 LOGIN_URL = 'saml2_login'
 LOGOUT_REDIRECT_URL = '/saml2/logged-out/'
 LOGIN_REDIRECT_URL = '/saml2/logged-in/'
-SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 SAML_USER_MODEL = 'user.user'
 
@@ -299,3 +298,7 @@ EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')
 EMAIL_PORT = env('EMAIL_PORT', default=587)
 EMAIL_FROM = env('EMAIL_FROM', default='test@example.com')
+
+# session settings
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False
+SESSION_COOKIE_AGE = 25*24*60*60

--- a/config/settings.py
+++ b/config/settings.py
@@ -301,4 +301,4 @@ EMAIL_FROM = env('EMAIL_FROM', default='test@example.com')
 
 # session settings
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-SESSION_COOKIE_AGE = 25*24*60*60
+SESSION_COOKIE_AGE = 90*24*60*60


### PR DESCRIPTION
User's are currently being asked to authenticate too frequently.  Presumably this is because the application (e.g. digital workspace) session has timed out, which means that the oauth2 token has been lost.  The user is then redirected back to the ABC to login, which will also have lost session meaning the user has to re-authenticate.

With this solution the user will remain logged in, so an oauth2 token will be allocated without the user having to go back through saml2/IdP authentication.