### PR TITLE
Make /o/introspect/ view use email precedence

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,8 +11,8 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^saml2/', include('sso.samlauth.urls')),
 
-    # override the DOT authorisation view
-    url(r'^o/authorize/$', CustomAuthorizationView.as_view(), name='authorize'),
+    # override authorisation and token introspection DOT views
+    url(r'^o/', include('sso.oauth2.urls', namespace='oauth2')),
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
     url(r'^api/v1/', include((api_urls, 'api'), namespace='api-v1')),

--- a/sso/oauth2/urls.py
+++ b/sso/oauth2/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import include, url
+
+from .views import CustomAuthorizationView, CustomIntrospectTokenView
+
+urlpatterns = [
+    url(r'^authorize/$', CustomAuthorizationView.as_view(), name='authorize'),
+    url(r"^introspect/$", CustomIntrospectTokenView.as_view(), name="introspect"),
+]
+


### PR DESCRIPTION
The /o/introspect/ view now determines the correct email to provide to the application based on the Application.email_order field.

NOTE: I haven't had time to add tests.