### PR TITLE
Add user/perms csv download

### DIFF
--- a/sso/core/dashboard.py
+++ b/sso/core/dashboard.py
@@ -38,7 +38,11 @@ class CustomIndexDashboard(Dashboard):
                 [_('Import user aliases'),
                  reverse('admin-user-alias-import')],
                 [_('Import and merge users'),
-                 reverse('admin-user-merge-import')]
+                 reverse('admin-user-merge-import')],
+                [_('Export user list'),
+                 reverse('user-export-view')],
+                [_('Export user permissions list'),
+                 reverse('user-permission-export-view')]
             ]
         ))
 

--- a/sso/user/admin_urls.py
+++ b/sso/user/admin_urls.py
@@ -1,11 +1,12 @@
 from django.conf.urls import url
 
 from .admin_views import (
-    AdminUserAliasAddImportView, AdminUserMergeImportView, download_user_csv
+    AdminUserAliasAddImportView, AdminUserMergeImportView, UserDataExportView, UserPermissionExportView
 )
 
 urlpatterns = [
     url(r'^user-import/$', AdminUserMergeImportView.as_view(), name='admin-user-merge-import'),
     url(r'^user-alias-import/$', AdminUserAliasAddImportView.as_view(), name='admin-user-alias-import'),
-    url(r'^user/csv-download/$', download_user_csv, name='user-csv-download'),
+    url(r'^user/export-list/$', UserDataExportView.as_view(), name='user-export-view'),
+    url(r'^user/export-permissions-list/$', UserPermissionExportView.as_view(), name='user-permission-export-view'),
 ]

--- a/sso/user/data_export.py
+++ b/sso/user/data_export.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+
+from sso.oauth2.models import Application
+
+
+class UserDataExport:
+    def __iter__(self):
+
+        yield ['email', 'first_name', 'last_name', 'other emails']
+
+        for user in get_user_model().objects.all().order_by('email'):
+            row = [user.email, user.first_name, user.last_name]
+
+            row.extend(user.emails.exclude(email=user.email).values_list('email', flat=True))
+
+            yield row
+
+
+class UserPermissionExport:
+    """This will export a list of users: primary email, first name, last name, **all applications"""
+
+    def get_application_list(self):
+        applications = list(Application.objects.all().values_list('id', 'name'))
+        self._app_ids, self._app_names = zip(*applications)
+
+    def get_query(self):
+        return get_user_model().objects.all().prefetch_related('permitted_applications').order_by('email')
+
+    def get_header(self):
+        return ['email', 'first_name', 'last_name'] + list(self._app_names)
+
+    def get_user_application_columns(self, user):
+        cols = []
+
+        for app_id in self._app_ids:
+            if user.permitted_applications.filter(pk=app_id).exists():
+                cols.append('y')
+            else:
+                cols.append('')
+
+        return cols
+
+    def format_row(self, user):
+        return [user.email, user.first_name, user.last_name] + self.get_user_application_columns(user)
+
+    def __iter__(self):
+        self.get_application_list()
+        users = self.get_query()
+
+        yield self.get_header()
+
+        for user in users:
+            yield self.format_row(user)

--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -18,7 +18,7 @@ class AdminUserUploadForm(forms.Form):
 
     file = forms.FileField(
         label='select a csv file',
-        required=False
+        required=True
     )
 
 
@@ -30,5 +30,5 @@ class AdminUserAddAliasForm(forms.Form):
 
     file = forms.FileField(
         label='select a csv file',
-        required=False
+        required=True
     )


### PR DESCRIPTION
What happened:
Created a base csv export view and refactored the existing csv download to use this.  
Added another csv export that provides a list of user details: email, first and last name, then a list of application columns indicating which permissions the each user has
These views have been added to the quick links panel of the dashboard

There's currently no tests for these views.  