### PR TITLE
DH requires their own scope

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -269,7 +269,7 @@ OAUTH2_PROVIDER = {
         'introspection': 'introspect scope',
         'data-hub:internal-front-end': 'A datahub specific scope'
     },
-    'DEFAULT_SCOPES': ['read', 'write'],
+    'DEFAULT_SCOPES': ['read', 'write', 'data-hub:internal-front-end'],
 }
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2.Application'


### PR DESCRIPTION
Currently every access token is given the datahub fe scope by default, irrespective of whether the token is for DH or not.

The DH app should explicitly request the 'data-hub:internal-front-end' token, rather than it being added to all tokens by default.

Once DH is requesting tokens with the correct scopes, 'data-hub:internal-front-end' can be removed from the default scopes list.