### PR TITLE
Make the email sign-in domain list configurable

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -297,16 +297,7 @@ RAVEN_CONFIG = {
 }
 
 # email auth
-EMAIL_TOKEN_DOMAIN_WHITELIST = [
-    ('@digital.trade.gov.uk', '@digital.trade.gov.uk'),
-    ('@trade.gsi.gov.uk', '@trade.gsi.gov.uk'),
-    ('@fco.gov.uk', '@fco.gov.uk'),
-    ('@fco.gsi.gov.uk', '@fco.gsi.gov.uk'),
-    ('@trade.gov.uk', '@trade.gov.uk'),
-    ('@cirrus.beis.gov.uk', '@cirrus.beis.gov.uk'),
-    ('@decc.gsi.gov.uk', '@decc.gsi.gov.uk'),
-    ('@dfid.gov.uk', '@dfid.gov.uk'),
-]
+EMAIL_TOKEN_DOMAIN_WHITELIST = env.tuple('EMAIL_TOKEN_DOMAIN_WHITELIST')
 
 EMAIL_TOKEN_TTL = 3600
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ env =
   SECRET_KEY=test secret key
   ALLOWED_HOSTS=localhost
 
+  EMAIL_TOKEN_DOMAIN_WHITELIST=@digital.trade.gov.uk,@trade.gov.uk
   SAML_REDIRECT_RETURN_HOST=http://localhost:8000
   ENV_NAME=test
 

--- a/sample.env
+++ b/sample.env
@@ -3,3 +3,4 @@ SECRET_KEY=do-not-use-in-prod
 DATABASE_URL=postgres://localhost/staff-sso
 SAML_REDIRECT_RETURN_HOST=http://localhost:8000
 ENV_NAME=test
+EMAIL_TOKEN_DOMAIN_WHITELIST=@digital.trade.gov.uk,@trade.gov.uk

--- a/sso/emailauth/forms.py
+++ b/sso/emailauth/forms.py
@@ -17,7 +17,7 @@ class EmailForm(forms.Form):
         widget=forms.TextInput(attrs={'class': 'form-control form-control-1-4', 'placeholder': 'i.e. john.smith5'})
     )
     domain = forms.ChoiceField(
-        choices=settings.EMAIL_TOKEN_DOMAIN_WHITELIST,
+        choices=zip(settings.EMAIL_TOKEN_DOMAIN_WHITELIST, settings.EMAIL_TOKEN_DOMAIN_WHITELIST),
         widget=forms.Select(attrs={'class': 'form-control form-control-1-4'})
     )
 

--- a/sso/tests/test_email_token.py
+++ b/sso/tests/test_email_token.py
@@ -91,7 +91,7 @@ class TestEmailTokenForm:
 
     def test_email_property(self):
 
-        domain = settings.EMAIL_TOKEN_DOMAIN_WHITELIST[0][0]
+        domain = settings.EMAIL_TOKEN_DOMAIN_WHITELIST[0]
 
         form = EmailForm({
             'username': 'test.user',
@@ -107,7 +107,7 @@ class TestEmailTokenForm:
         assert form.email == form.cleaned_data['username'] + form.cleaned_data['domain']
 
     def test_invalid_username_is_detected(self):
-        domain = settings.EMAIL_TOKEN_DOMAIN_WHITELIST[0][0]
+        domain = settings.EMAIL_TOKEN_DOMAIN_WHITELIST[0]
 
         form = EmailForm({
             'username': 'invalid@username.com',


### PR DESCRIPTION
The intention is to add `@beis.gov.uk` and remove `@trade.gsi.gov.uk` and `@digital.trade.gov.uk`.