### PR TITLE
Update Django and psycopg2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,7 +39,7 @@ lxml==4.1.1
 mccabe==0.6.1             # via flake8, mccabe
 oauthlib==2.0.2
 paste==2.0.3
-psycopg2==2.7.1
+psycopg2==2.7.5
 py==1.5.2                 # via pytest
 pycodestyle==2.3.1        # via flake8, flake8-debugger, flake8-import-order, flake8-print, pycodestyle
 pycparser==2.17

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ django-admin-tools==0.8.1
 django-axes==2.3.3
 django-environ==0.4.3
 django-oauth-toolkit==1.0.0
-django==1.11.2
+django==1.11.13
 djangorestframework==3.6.3
 djangosaml2==0.16.0
 factory-boy==2.9.2
@@ -36,12 +36,12 @@ future==0.16.0
 idna==2.5
 isort==4.2.15
 lxml==4.1.1
-mccabe==0.6.1             # via flake8
+mccabe==0.6.1             # via flake8, mccabe
 oauthlib==2.0.2
 paste==2.0.3
 psycopg2==2.7.1
 py==1.5.2                 # via pytest
-pycodestyle==2.3.1        # via flake8, flake8-debugger, flake8-import-order, flake8-print
+pycodestyle==2.3.1        # via flake8, flake8-debugger, flake8-import-order, flake8-print, pycodestyle
 pycparser==2.17
 pycryptodomex==3.4.6
 pyflakes==1.6.0           # via flake8
@@ -59,7 +59,7 @@ raven==6.3.0
 repoze.who==2.3
 requests==2.19.1
 six==1.10.0
-termcolor==1.1.0          # via pytest-sugar
+termcolor==1.1.0          # via pytest-sugar, termcolor
 text-unidecode==1.1       # via faker
 urllib3==1.21.1
 waitress==1.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django
+Django<2.0.0
 django-environ
 psycopg2
 djangosaml2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ asn1crypto==0.22.0        # via cryptography
 cachetools==2.0.1         # via zenpy
 certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography
-chardet==3.0.4            # via requests
+chardet==3.0.4            # via chardet, requests
 cryptography==1.9         # via pyopenssl
 decorator==4.0.11         # via pysaml2
 defusedxml==0.4.1         # via djangosaml2
@@ -18,10 +18,10 @@ django-admin-tools==0.8.1
 django-axes==2.3.3
 django-environ==0.4.3
 django-oauth-toolkit==1.0.0
-django==1.11.2
+django==1.11.13           # via django-environ, django-oauth-toolkit
 djangorestframework==3.6.3
 djangosaml2==0.16.0
-future==0.16.0            # via pysaml2, zenpy
+future==0.16.0            # via future, pysaml2, zenpy
 idna==2.5                 # via cryptography, requests
 oauthlib==2.0.2           # via django-oauth-toolkit
 paste==2.0.3              # via pysaml2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,14 +18,14 @@ django-admin-tools==0.8.1
 django-axes==2.3.3
 django-environ==0.4.3
 django-oauth-toolkit==1.0.0
-django==1.11.13           # via django-environ, django-oauth-toolkit
+django==1.11.13
 djangorestframework==3.6.3
 djangosaml2==0.16.0
 future==0.16.0            # via future, pysaml2, zenpy
 idna==2.5                 # via cryptography, requests
 oauthlib==2.0.2           # via django-oauth-toolkit
 paste==2.0.3              # via pysaml2
-psycopg2==2.7.1
+psycopg2==2.7.5
 pycparser==2.17           # via cffi
 pycryptodomex==3.4.6      # via pysaml2
 pyopenssl==17.0.0         # via pysaml2


### PR DESCRIPTION
This updates Django to the latest 1.11.x version and also updates psycopg2.

Unfortunately a version of djangosaml2 supporting pysaml2 4.5.0 hasn't been released yet (the latest commit on GitHub does though).