### PR TITLE
Django 2 needs on_delete specified - set it to the django 1 default o…

### DIFF
--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -145,7 +145,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
 
 class EmailAddress(models.Model):
-    user = models.ForeignKey(User, related_name='emails')
+    user = models.ForeignKey(User, related_name='emails', on_delete=models.CASCADE)
     email = models.EmailField(unique=True)
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Django 2 needs on_delete specified - set it to the django 1 default of ON_CASCADE.

A lot of the py-up upgrades are trying to go with libraries that need django 2.

This doesn't do the upgrade, but should unblock all the pyup tickets that need it, starting at  https://github.com/uktrade/staff-sso/pull/97