### PR TITLE
Bump django-axes to 4.4.0

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -288,6 +288,18 @@ LOGGING = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    'axes_cache': {
+        # See - https://github.com/jazzband/django-axes/blob/master/docs/configuration.rst#cache-problems
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+AXES_CACHE = 'axes_cache'
+
 # admin ip restriction
 RESTRICT_ADMIN_BY_IPS = env('RESTRICT_ADMIN_BY_IPS')
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -16,5 +16,4 @@ flake8-import-order
 flake8-print
 flake8-quotes
 
-isort
 lxml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,18 +12,23 @@ cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
+configparser==3.5.0       # via flake8
+contextlib2==0.5.5
 coverage==4.5.1           # via pytest-cov
 cryptography==2.2.2
 decorator==4.2.1
 defusedxml==0.4.1
 dj-database-url==0.5.0
 django-admin-tools==0.8.1
+django-appconf==1.0.2
 django-axes==4.4.0
 django-environ==0.4.4
+django-ipware==2.1.0
 django-oauth-toolkit==1.1.0
 django==1.11.13
 djangorestframework==3.8.2
 djangosaml2==0.16.0
+enum34==1.1.6
 factory-boy==2.11.1
 faker==0.8.7              # via factory-boy
 flake8-blind-except==0.1.1
@@ -33,11 +38,15 @@ flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8==3.5.0
 freezegun==0.3.10
+funcsigs==1.0.2           # via pytest
 future==0.16.0
+futures==3.2.0            # via isort
 idna==2.5
+ipaddress==1.0.22
 isort==4.3.4
 lxml==4.2.1
 mccabe==0.6.1             # via flake8
+mock==2.0.0               # via pytest-mock
 more-itertools==4.2.0     # via pytest
 oauthlib==2.0.3
 paste==2.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,10 +40,8 @@ flake8==3.5.0
 freezegun==0.3.10
 funcsigs==1.0.2           # via pytest
 future==0.16.0
-futures==3.2.0            # via isort
 idna==2.5
 ipaddress==1.0.22
-isort==4.3.4
 lxml==4.2.1
 mccabe==0.6.1             # via flake8
 mock==2.0.0               # via pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,6 @@ cachetools==2.1.0
 certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
-configparser==3.5.0       # via flake8
-contextlib2==0.5.5
 coverage==4.5.1           # via pytest-cov
 cryptography==2.2.2
 decorator==4.2.1
@@ -28,7 +26,6 @@ django-oauth-toolkit==1.1.0
 django==1.11.13
 djangorestframework==3.8.2
 djangosaml2==0.16.0
-enum34==1.1.6
 factory-boy==2.11.1
 faker==0.8.7              # via factory-boy
 flake8-blind-except==0.1.1
@@ -38,13 +35,10 @@ flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8==3.5.0
 freezegun==0.3.10
-funcsigs==1.0.2           # via pytest
 future==0.16.0
 idna==2.5
-ipaddress==1.0.22
 lxml==4.2.1
 mccabe==0.6.1             # via flake8
-mock==2.0.0               # via pytest-mock
 more-itertools==4.2.0     # via pytest
 oauthlib==2.0.3
 paste==2.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ decorator==4.2.1
 defusedxml==0.4.1
 dj-database-url==0.5.0
 django-admin-tools==0.8.1
-django-axes==2.3.3
+django-axes==4.4.0
 django-environ==0.4.4
 django-oauth-toolkit==1.1.0
 django==1.11.13

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,6 @@ zenpy
 waitress
 whitenoise
 dj-database-url
-django-axes
+django-axes==4.4.0
 -e git+https://github.com/uktrade/dit-ip@v1.1.0#egg=django-ip-restriction
 raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ decorator==4.2.1          # via pysaml2
 defusedxml==0.4.1         # via djangosaml2
 dj-database-url==0.5.0
 django-admin-tools==0.8.1
-django-axes==2.3.3
+django-axes==4.4.0
 django-environ==0.4.4
 django-oauth-toolkit==1.1.0
 django==1.11.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,19 +10,24 @@ cachetools==2.1.0         # via zenpy
 certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
+contextlib2==0.5.5        # via raven
 cryptography==2.2.2       # via pyopenssl
 decorator==4.2.1          # via pysaml2
 defusedxml==0.4.1         # via djangosaml2
 dj-database-url==0.5.0
 django-admin-tools==0.8.1
+django-appconf==1.0.2     # via django-axes
 django-axes==4.4.0
 django-environ==0.4.4
+django-ipware==2.1.0      # via django-axes
 django-oauth-toolkit==1.1.0
 django==1.11.13
 djangorestframework==3.8.2
 djangosaml2==0.16.0
+enum34==1.1.6             # via cryptography
 future==0.16.0            # via pysaml2, zenpy
 idna==2.5                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography
 oauthlib==2.0.3           # via django-oauth-toolkit
 paste==2.0.3              # via pysaml2
 psycopg2==2.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ cachetools==2.1.0         # via zenpy
 certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-contextlib2==0.5.5        # via raven
 cryptography==2.2.2       # via pyopenssl
 decorator==4.2.1          # via pysaml2
 defusedxml==0.4.1         # via djangosaml2
@@ -24,10 +23,8 @@ django-oauth-toolkit==1.1.0
 django==1.11.13
 djangorestframework==3.8.2
 djangosaml2==0.16.0
-enum34==1.1.6             # via cryptography
 future==0.16.0            # via pysaml2, zenpy
 idna==2.5                 # via cryptography, requests
-ipaddress==1.0.22         # via cryptography
 oauthlib==2.0.3           # via django-oauth-toolkit
 paste==2.0.3              # via pysaml2
 psycopg2==2.7.5

--- a/sso/localauth/urls.py
+++ b/sso/localauth/urls.py
@@ -1,9 +1,9 @@
-from axes.decorators import watch_login
+from axes.decorators import axes_dispatch
 from django.conf.urls import url
 
 from sso.localauth import views
 
 urlpatterns = [
-    url(r'^login/$', watch_login(views.LoginView.as_view()), name='login'),
+    url(r'^login/$', axes_dispatch(views.LoginView.as_view()), name='login'),
     url(r'^logout/$', views.session_logout, name='session-logout'),
 ]


### PR DESCRIPTION
Hi
   @lgarvey this is prerequisite to upgrading to django 2.   The bit that might be fun is they renamed watch_login to axes_dispatch  ... well, I assume it's a simple rename, the tests pass ..

S

~EDIT:  The tests don't pass ;(~