### PR TITLE
Fix introspection view logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ config/saml/prod/*.crt
 .envrc
 .pytest_cache
 
+*.swp
+
+.pytest_cache


### PR DESCRIPTION
Ensure that the introspecting_application is correctly determined.  The previouis approach of selecting the first access token associated with `request.resource_owner` lead to problems because all valid tokens associated with the user, across applications, is returned. Instead we're now determining the introspecting application based on the Authorization header.