### PR TITLE
Add Email auth page interstitial login page

### DIFF
--- a/sso/emailauth/urls.py
+++ b/sso/emailauth/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from django.views.generic import TemplateView
 
-from .views import EmailAuthView, EmailTokenView, InvalidToken
+from .views import EmailAuthView, EmailTokenView
 
 app_name = 'emailauth'
 
@@ -11,5 +11,4 @@ urlpatterns = [
     url(r'^token/success/$',
         TemplateView.as_view(template_name='emailauth/complete.html'),
         name='email-auth-initiate-success'),
-    url(r'^invalid-token/$', InvalidToken.as_view(), name='email-auth-invalid-token')
 ]

--- a/sso/templates/emailauth/signin.html
+++ b/sso/templates/emailauth/signin.html
@@ -1,0 +1,16 @@
+{% extends 'sso/base.html' %}
+
+{% block inner_content %}
+
+<div class="container">
+    <h1 class="heading-large">Sign in to DIT internal services</h1>
+
+    <p>Accessing DIT internal services with username: {{ user }}</p>
+    <form method="post" action="{{ request.path }}">
+        <button type="submit" class="button">Complete Sign-in</button>
+
+        {% csrf_token %}
+    </form>
+</div>
+
+{% endblock %}

--- a/sso/templates/emailauth/signin.html
+++ b/sso/templates/emailauth/signin.html
@@ -6,7 +6,7 @@
     <h1 class="heading-large">Sign in to DIT internal services</h1>
 
     <p>Accessing DIT internal services with username: {{ user }}</p>
-    <form method="post" action="{{ request.path }}">
+    <form method="post" action="{{ request.get_full_path }}">
         <button type="submit" class="button">Complete Sign-in</button>
 
         {% csrf_token %}


### PR DESCRIPTION
This prevents the URL from being invalidated before the user is able to use the link.  Some software such as slack or firewall systems will access the link thus invalidating it before the user has been able to authenticate.  Now an intermediate page is displayed and the user has to click the login button on that page to authenticate.