### PR TITLE
Bugfix sync script

### DIFF
--- a/sso/samlidp/management/commands/sync_with_google.py
+++ b/sso/samlidp/management/commands/sync_with_google.py
@@ -124,9 +124,9 @@ class Command(BaseCommand):
         template = {
             'primaryEmail': primary_email,
             'name': {
-                'givenName': user.first_name,
-                'familyName': user.last_name,
-                'fullName': user.get_full_name()
+                'givenName': user.first_name or 'unspecified',
+                'familyName': user.last_name or 'unspecified',
+                'fullName': user.get_full_name(),
             },
             'password': hashlib.sha1(password).hexdigest(),
             'hashFunction': 'SHA-1',


### PR DESCRIPTION
The google API requires a first and last name when creating a user. IF these are missing in staff-sso, it would kill the sync script.

This amend sets the name fields to 'unspecified' if they aren't set.