### PR TITLE
Allow overriding MI email

### DIFF
--- a/sso/samlidp/management/commands/sync_with_google.py
+++ b/sso/samlidp/management/commands/sync_with_google.py
@@ -163,7 +163,7 @@ class Command(BaseCommand):
             access_profiles__slug__in=settings.MI_GOOGLE_USER_SYNC_ACCESS_PROFILES)
 
         for user in local_users:
-            remote_email = build_google_user_id(user.email)
+            remote_email = build_google_user_id(user)
 
             logger.info('remote email: %s', remote_email)
 

--- a/sso/samlidp/processors.py
+++ b/sso/samlidp/processors.py
@@ -4,20 +4,25 @@ from django.conf import settings
 
 from djangosaml2idp.processors import BaseProcessor
 
+
 from .models import SamlApplication
+from sso.user.models import EmailAddress
 
 
 logger = logging.getLogger(__name__)
 
 
-def build_google_user_id(email):
+def build_google_user_id(user):
     """
     Construct a google email address from the user's primary email.
     """
 
-    return '{}@{}'.format(
-        email.split('@')[0],
-        settings.MI_GOOGLE_EMAIL_DOMAIN)
+    try:
+        return user.emails.get(email__endswith='@'+settings.MI_GOOGLE_EMAIL_DOMAIN).email
+    except EmailAddress.DoesNotExist:
+        return '{}@{}'.format(
+            user.email.split('@')[0],
+            settings.MI_GOOGLE_EMAIL_DOMAIN)
 
 
 class ModelProcessor(BaseProcessor):
@@ -56,4 +61,4 @@ class AWSProcessor(ModelProcessor):
 class GoogleProcessor(ModelProcessor):
     def get_user_id(self, user):
 
-        return build_google_user_id(user.email)
+        return build_google_user_id(user)

--- a/sso/tests/test_samlidp.py
+++ b/sso/tests/test_samlidp.py
@@ -98,3 +98,14 @@ class TestGoogleProcessor:
 
         processor = GoogleProcessor(entity_id='an_entity_id')
         assert processor.get_user_id(user) == 'hello@test.com'
+
+    def test_email_can_be_overridden(self, settings):
+        SamlApplicationFactory(entity_id='an_entity_id')
+        settings.MI_GOOGLE_EMAIL_DOMAIN = 'test.com'
+
+        user = UserFactory(email='hello@world.com', email_list=[
+            'hello_world@' + settings.MI_GOOGLE_EMAIL_DOMAIN
+        ])
+
+        processor = GoogleProcessor(entity_id='an_entity_id')
+        assert processor.get_user_id(user) == 'hello_world@test.com'


### PR DESCRIPTION
The sync logic takes the user's primary email username and adds it to MI google domain to create the MI user.  However, this poses problems when we have multiple users with the same name. This PR adds the ability to manually override the MI google domain by adding a secondary email for the user.