### PR TITLE
Simplify the oauth2 application admin display

### DIFF
--- a/sso/oauth2/admin.py
+++ b/sso/oauth2/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
-from oauth2_provider.models import get_access_token_model
+from oauth2_provider.models import get_access_token_model, get_application_model
 
 
 AccessToken = get_access_token_model()
+Application = get_application_model()
 
 
 class AccessTokenAdmin(admin.ModelAdmin):
@@ -10,5 +11,18 @@ class AccessTokenAdmin(admin.ModelAdmin):
     raw_id_fields = ('user', 'source_refresh_token')
 
 
+class ApplicationAdmin(admin.ModelAdmin):
+    list_display = ('name', 'default_access_allowed', 'allow_access_by_email_suffix', 'allow_tokens_from_display')
+    raw_id_fields = ('user', )
+    exclude = ('client_type', 'authorization_grant_type', 'skip_authorization')
+
+    def allow_tokens_from_display(self, obj):
+        return ', '.join(app.name for app in obj.allow_tokens_from.all())
+
+    allow_tokens_from_display.short_description = 'allow tokens from'
+
 admin.site.unregister(AccessToken)
 admin.site.register(AccessToken, AccessTokenAdmin)
+
+admin.site.unregister(Application)
+admin.site.register(Application, ApplicationAdmin)

--- a/sso/oauth2/models.py
+++ b/sso/oauth2/models.py
@@ -47,6 +47,15 @@ class Application(AbstractApplication):
 
     allow_tokens_from = models.ManyToManyField('self', blank=True, symmetrical=False)
 
+    def save(self, *args, **kwargs):
+
+        # these fields are not user configurable
+        self.client_type = 'confidential'
+        self.authorization_grant_type = 'authorization-code'
+        self.skip_authorization = True
+
+        super().save(*args, **kwargs)
+
     def get_email_order(self):
         ordering = self.email_ordering or getattr(settings, 'DEFAULT_EMAIL_ORDER', '')
 


### PR DESCRIPTION
OAuth2 specific fields have been removed from the admin page and defaults set when the model is saved