### PR TITLE
Disable session samesite setting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -350,6 +350,7 @@ EMAIL_FROM = env('EMAIL_FROM', default='test@example.com')
 # session settings
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SESSION_COOKIE_AGE = 24 * 60 * 60
+SESSION_COOKIE_SAMESITE = None
 
 # google analytics
 GOOGLE_ANALYTICS_CODE = env('GOOGLE_ANALYTICS_CODE', default=None)


### PR DESCRIPTION
The same-site setting breaks saml2 authentication.

I'll add a trello ticket to investigate and see if there's a way we can re-enable same-site with saml2.

This breaks the app - need to under