### PR TITLE
Make user api endpoint queryable by user_id

### DIFF
--- a/sso/tests/test_user_api.py
+++ b/sso/tests/test_user_api.py
@@ -231,7 +231,26 @@ class TestApiUserIntrospect:
             'access_profiles': []
         }
 
-    def test_requires_email(self, api_client):
+    def test_with_user_id(self, api_client):
+        user, token = get_oauth_token(scope='introspection')
+
+        app = ApplicationFactory(users=[user])
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        response = api_client.get(self.GET_USER_INTROSPECT_URL + '?user_id={}'.format(str(user.user_id)))
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'email': 'user1@example.com',
+            'user_id': str(user.user_id),
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'related_emails': [],
+            'groups': [],
+            'permitted_applications': [{'key': app.application_key, 'name': app.display_name, 'url': app.start_url}],
+            'access_profiles': []
+        }
+
+    def test_requires_email_or_user_id(self, api_client):
         user, token = get_oauth_token(scope='introspection')
 
         api_client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import PermissionsMixin
 from django.db import models
-from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -33,5 +33,13 @@ class UserSerializer(serializers.ModelSerializer):
         }
 
 
-class EmailParamSerializer(serializers.Serializer):
-    email = serializers.EmailField()
+class UserParamSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=False, default=None)
+    user_id = serializers.UUIDField(required=False, default=None)
+
+    def validate(self, data):
+        if not data['email'] and not data['user_id']:
+            raise serializers.ValidationError('Either an email or a user_id is required')
+
+        return data
+

--- a/sso/user/views.py
+++ b/sso/user/views.py
@@ -3,7 +3,7 @@ from oauth2_provider.contrib.rest_framework import TokenHasScope
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.response import Response
 
-from .serializers import EmailParamSerializer, UserSerializer
+from .serializers import UserSerializer, UserParamSerializer
 
 
 class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
@@ -20,17 +20,18 @@ class UserIntrospectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = UserSerializer
 
     def retrieve(self, request):
-        serializer = EmailParamSerializer(data=request.query_params)
-
-        if serializer.is_valid(raise_exception=True):
-            email = serializer.validated_data['email']
 
         User = get_user_model()
 
-        try:
-            selected_user = User.objects.get_by_email(email)
-        except User.DoesNotExist:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+        serializer = UserParamSerializer(data=request.query_params)
+        if serializer.is_valid(raise_exception=True):
+            try:
+                if serializer.validated_data['email']:
+                    selected_user = User.objects.get_by_email(serializer.validated_data['email'])
+                else:
+                    selected_user = User.objects.get(user_id=serializer.validated_data['user_id'])
+            except User.DoesNotExist:
+                return Response(status=status.HTTP_404_NOT_FOUND)
 
         if not selected_user.can_access(request.auth.application):
             # The user does not have permission to access this OAuth2 application


### PR DESCRIPTION
These changes are so that digital workspace can migrate away from keying user details on email and instead use the user_id guid