### PR TITLE
Add management command to impersonate user

### DIFF
--- a/sso/user/management/commands/get_user_login_url.py
+++ b/sso/user/management/commands/get_user_login_url.py
@@ -1,0 +1,36 @@
+import urllib.parse
+
+from sso.emailauth.models import EmailToken
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.urls import reverse
+
+
+class Command(BaseCommand):
+    help = 'Get a one-time authenticate url to impersonate an SSO user'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--email',
+            dest='user_email',
+            help='The email of the user you want to impersonate. A user with this email must already exist',
+        )
+
+    def handle(self, *args, user_email, **kwargs):
+
+        User = get_user_model()
+
+        # verify that the user exists in the DB
+        try:
+            User.objects.get_by_email(user_email)
+        except User.DoesNotExist:
+            self.stdout.write('User %s does not exist', user_email)
+            return 1
+
+        token = EmailToken.objects.create_token(user_email)
+
+        path = reverse('emailauth:email-auth-signin', kwargs=dict(token=token))
+
+        return urllib.parse.urljoin(settings.BASE_URL, path)


### PR DESCRIPTION
We have a requirement for the webops team to impersonate users on staff-sso to debug access issues.

This PR adds a management command that allows a technical team member (webops predominantly) to generate a one-time authorisation url for a specific user via a Django management command.