### PR TITLE
Session timeout after period of inactivity

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django_session_timeout.middleware.SessionTimeoutMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -364,8 +365,9 @@ EMAIL_FROM = env('EMAIL_FROM', default='test@example.com')
 
 # session settings
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-SESSION_COOKIE_AGE = env.int('SESSION_COOKIE_AGE_SECONDS')
+SESSION_EXPIRE_SECONDS = env.int('SESSION_COOKIE_AGE_SECONDS')
 SESSION_COOKIE_SAMESITE = None
+SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
 
 # google analytics
 GOOGLE_ANALYTICS_CODE = env('GOOGLE_ANALYTICS_CODE', default=None)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ django-environ==0.4.5
 django-filter==2.1.0
 django-ipware==2.1.0
 django-oauth-toolkit==1.1.0
+django-session-timeout==0.0.4
 django==2.2.3
 djangorestframework==3.10.1
 djangosaml2==0.17.2
@@ -66,7 +67,7 @@ pytz==2018.5
 raven==6.9.0
 requests==2.20.1
 rsa==4.0
-six==1.11.0
+six==1.12.0
 sqlparse==0.3.0
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
@@ -77,4 +78,4 @@ whitenoise==4.1.3
 zenpy==2.0.6
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.0.1        # via flake8-blind-except, flake8-import-order, pytest
+# setuptools==41.1.0        # via flake8-blind-except, flake8-import-order, pytest

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,8 @@ psycopg2-binary
 djangosaml2==0.17.2
 django-oauth-toolkit==1.1.0
 djangorestframework
+django-filter==2.1.0
+django-session-timeout
 zenpy
 requests==2.20.1
 defusedxml==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-environ==0.4.5
 django-filter==2.1.0
 django-ipware==2.1.0      # via django-axes
 django-oauth-toolkit==1.1.0
+django-session-timeout==0.0.4
 django==2.2.3
 djangorestframework==3.10.1
 djangosaml2==0.17.2
@@ -41,7 +42,7 @@ pytz==2018.5              # via django, django-axes, pysaml2, zenpy
 raven==6.9.0
 requests==2.20.1
 rsa==4.0                  # via google-auth, oauth2client
-six==1.11.0               # via cryptography, google-api-python-client, google-auth, oauth2client, pyopenssl, pysaml2, python-dateutil
+six==1.12.0               # via cryptography, django-session-timeout, google-api-python-client, google-auth, oauth2client, pyopenssl, pysaml2, python-dateutil
 sqlparse==0.3.0           # via django
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.24.2           # via requests


### PR DESCRIPTION
We require SSO sessions to timeout after a period of inactivity rather by after a fixed period of time. This PR uses a community module which provides middleware to track a user's last request time and will flush the session when this exceeds `settings.SESSION_EXPIRE_SECONDS`