### PR TITLE
adding contact_email in the user response in both introspect and search

### DIFF
--- a/sso/user/admin.py
+++ b/sso/user/admin.py
@@ -43,7 +43,7 @@ class UserAdmin(admin.ModelAdmin):
 
     search_fields = ('emails__email', 'email', 'first_name', 'last_name')
     list_filter = (ApplicationFilter, 'is_superuser')
-    fields = ('user_id', 'email', 'first_name', 'last_name', 'date_joined', 'last_login', 'last_accessed',
+    fields = ('user_id', 'email', 'first_name', 'last_name', 'contact_email', 'date_joined', 'last_login', 'last_accessed',
               'access_profiles', 'permitted_applications', 'list_user_settings_wrapper')
     readonly_fields = ('date_joined', 'last_login', 'last_accessed', 'user_id', 'list_user_settings_wrapper')
     list_display = ('email', 'email_list', 'is_superuser', 'last_login', 'last_accessed',

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -122,6 +122,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
 
         self.email = self.email.lower()
+        self.contact_email = self.contact_email.lower()
 
         if 'email' in kwargs:
             kwargs['email'] = kwargs['email'].lower()

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -27,6 +27,7 @@ class UserSerializer(serializers.ModelSerializer):
             'first_name': obj.first_name,
             'last_name': obj.last_name,
             'related_emails': related_emails,
+            'contact_email': obj.contact_email,
             'groups': [],
             'permitted_applications': obj.get_permitted_applications(),
             'access_profiles': [profile.slug for profile in obj.access_profiles.all()]
@@ -63,6 +64,7 @@ class UserListSerializer(serializers.Serializer):
             'first_name',
             'last_name',
             'email',
+            'contact_email',
         )
 
     def to_representation(self, obj):
@@ -75,4 +77,5 @@ class UserListSerializer(serializers.Serializer):
             'first_name': obj.first_name,
             'last_name': obj.last_name,
             'email': primary_email,
+            'contact_email': obj.contact_email,
         }


### PR DESCRIPTION
Existing and unused contact_email field will now be part of response for both user introspect and search API endpoints. This will enable applications like Market Access to use this field for various options, where it needs to show user's contactable email address reliably.