### PR TITLE
lower case emails supplied in saml2 ACS response

### DIFF
--- a/sso/user/managers.py
+++ b/sso/user/managers.py
@@ -60,6 +60,6 @@ class UserManager(BaseUserManager):
     def set_email_last_login_time(self, email):
         from sso.user.models import EmailAddress
 
-        email_obj = EmailAddress.objects.get(email=email)
+        email_obj = EmailAddress.objects.get(email=email.lower())
         email_obj.last_login = timezone.now()
         email_obj.save()


### PR DESCRIPTION
Emails are sometimes supplied by the ADFS mixed case format, etc.  'John.Smith@example.com', and this causes an error when we try to match locally.

This PR lowercases the email just prior to searching for it in the database