### PR TITLE
Fix SameSite Saml2.0 bug

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'sso.core.middleware.SessionCookieFixMiddleware',
     'sso.healthcheck.middleware.HealthCheckMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -72,7 +73,6 @@ MIDDLEWARE = [
     'sso.core.middleware.NeverCacheMiddleware',
     'sso.user.middleware.UpdatedLastAccessedMiddleware',
     'sso.core.middleware.AdminIpRestrictionMiddleware',
-
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -367,7 +367,8 @@ EMAIL_FROM = env('EMAIL_FROM', default='test@example.com')
 # session settings
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SESSION_COOKIE_AGE = env.int('SESSION_COOKIE_AGE_SECONDS')
-SESSION_COOKIE_SAMESITE = None
+SESSION_COOKIE_SAMESITE = 'Lax' # this is currently overridden in middleware
+SESSION_COOKIE_SECURE = True
 SESSION_SAVE_EVERY_REQUEST = True
 
 # google analytics

--- a/config/settings.py
+++ b/config/settings.py
@@ -308,7 +308,7 @@ LOGGING = {
     },
     'root': {
         'handlers': ['console'],
-        'level': 'WARN',
+        'level': 'INFO',
     },
     'loggers': {
         'x-auth': {

--- a/sso/core/middleware.py
+++ b/sso/core/middleware.py
@@ -33,3 +33,17 @@ def AdminIpRestrictionMiddleware(get_response):
         return get_response(request)
 
     return middleware
+
+
+class SessionCookieFixMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        response = self.get_response(request)
+
+        if 'sessionid' in response.cookies:
+            response.cookies['sessionid']['SameSite'] = 'None'
+
+        return response

--- a/sso/samlauth/views.py
+++ b/sso/samlauth/views.py
@@ -244,14 +244,6 @@ def assertion_consumer_service(request,
     oq_cache = OutstandingQueriesCache(request.session)
     outstanding_queries = oq_cache.outstanding_queries()
 
-    logger.info('------------ START LOGGING ------------')
-    decoded_xml = base64.b64decode(xmlstr)
-    logger.info(f'Saml response: {decoded_xml}')
-    logger.info(f'Outstanding queries: {request.session.items()}')
-    logger.info(f'Session key: {request.session.session_key}')
-    logger.info(f'cookies: {request.COOKIES.items()}')
-    logger.info('------------ END LOGGING ------------')
-
     try:
         response = client.parse_authn_request_response(xmlstr, BINDING_HTTP_POST, outstanding_queries)
     except (StatusError, ToEarly):

--- a/sso/samlauth/views.py
+++ b/sso/samlauth/views.py
@@ -244,6 +244,14 @@ def assertion_consumer_service(request,
     oq_cache = OutstandingQueriesCache(request.session)
     outstanding_queries = oq_cache.outstanding_queries()
 
+    logger.info('------------ START LOGGING ------------')
+    decoded_xml = base64.b64decode(xmlstr)
+    logger.info(f'Saml response: {decoded_xml}')
+    logger.info(f'Outstanding queries: {request.session.items()}')
+    logger.info(f'Session key: {request.session.session_key}')
+    logger.info(f'cookies: {request.COOKIES.items()}')
+    logger.info('------------ END LOGGING ------------')
+
     try:
         response = client.parse_authn_request_response(xmlstr, BINDING_HTTP_POST, outstanding_queries)
     except (StatusError, ToEarly):


### PR DESCRIPTION
Newer versions of Chrome default the cookie SameSite setting to lax, which breaks the saml2.0 workflow. 

On top this we can't remediate the problem with django 2.10.11 due to the way it handles samesite settings.  So temporarily a small piece of middleware has been added to set the correct samesite value for sessionid cookies.  This middleware will be removed in due course as we migrate to django 3.x.

