### PR TITLE
(feat) Add permitted applications to activity stream

### DIFF
--- a/sso/oauth2/models.py
+++ b/sso/oauth2/models.py
@@ -92,3 +92,7 @@ class Application(AbstractApplication):
             return []
 
         return [email.strip() for email in ordering.split(',')]
+
+    @staticmethod
+    def get_default_access_applications():
+        return Application.objects.filter(default_access_allowed=True)

--- a/sso/samlidp/models.py
+++ b/sso/samlidp/models.py
@@ -54,6 +54,18 @@ class SamlApplication(models.Model):
         help_text=_('Is this integration enabled?'),
     )
 
+    @property
+    def public(self):
+        return False
+
+    @property
+    def display_name(self):
+        return self.name
+
+    @property
+    def application_key(self):
+        return self.entity_id
+
     def __str__(self):
         return self.name
 

--- a/sso/tests/factories/user.py
+++ b/sso/tests/factories/user.py
@@ -45,6 +45,15 @@ class UserFactory(factory.django.DjangoModelFactory):
             for profile in extracted:
                 self.access_profiles.add(profile)
 
+    @factory.post_generation
+    def add_permitted_applications(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            for app in extracted:
+                self.permitted_applications.add(app)
+
 
 class AccessProfileFactory(factory.django.DjangoModelFactory):
     slug = factory.Sequence(lambda n: f'access-profile-{n+1}')

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -326,7 +326,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         else:
             return self.get_emails_for_application(application)[0]
 
-    def get_permitted_applications(self, include_non_public=False):
+    def get_permitted_applications(self, include_non_public=False,
+        get_default_access_allowed_apps=OAuthApplication.get_default_access_applications):
         """Return a list of applications that this user has access to"""
 
         def _extract(app):
@@ -340,8 +341,9 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         for ap in self.access_profiles.all():
             apps.update(set(ap.oauth2_applications.all()))
+            apps.update(set(ap.saml2_applications.all()))
 
-        apps.update(set(OAuthApplication.objects.filter(default_access_allowed=True)))
+        apps.update(set(get_default_access_allowed_apps()))
 
         permitted_apps = sorted(list(apps), key=lambda el: el.display_name)
 


### PR DESCRIPTION
Not sure of any consequences of adding SAML2 applications to the response of get_permitted_applications, or if how I've made the the SAML2 applications appear like the Oauth apps using `@property` is suitable. 