### PR TITLE
Fix aws integration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -478,6 +478,7 @@ SAML_IDP_SPCONFIG = {
         'attribute_mapping': {},
         'extra_config': {
             'role': SAML2_APPSTREAM_AWS_ROLE_ARN,
+            'user_id_field': 'user_id',
         }
     },
     'google.com': {

--- a/sso/samlidp/processors.py
+++ b/sso/samlidp/processors.py
@@ -63,6 +63,8 @@ class ModelProcessor(BaseProcessor):
 
 
 class AWSProcessor(ModelProcessor):
+    USER_ID_FIELD = 'user_id'
+
     def create_identity(self, user, sp_mapping, **extra_config):
 
         role_arn = extra_config.pop('role', None)

--- a/sso/tests/test_samlidp.py
+++ b/sso/tests/test_samlidp.py
@@ -237,6 +237,29 @@ class TestAWSProcessor:
 
         assert identity['https://aws.amazon.com/SAML/Attributes/RoleSessionName'] == str(user.user_id)
 
+    def test_get_user_field_supplies_email(self):
+        user = UserFactory()
+
+        SamlApplicationFactory(entity_id='an_entity_id')
+        processor = AWSProcessor(entity_id='an_entity_id', sp_config={})
+
+        assert processor.get_user_id(user) == user.email
+
+    def test_get_user_field_overrideable_by_config(self):
+        user = UserFactory()
+
+        sp_config = {
+            'attribute_mapping': {},
+            'extra_config': {
+                'user_id_field': 'user_id',
+            }
+        }
+
+        SamlApplicationFactory(entity_id='an_entity_id')
+        processor = AWSProcessor(entity_id='an_entity_id', sp_config=sp_config)
+
+        assert processor.get_user_id(user) ==  str(user.user_id)
+
 
 class TestGoogleProcessor:
     def test_correct_email_is_supplied(self, settings):
@@ -300,7 +323,7 @@ class TestIdpInitiatedLogin:
 
         settings.SAML_IDP_SPCONFIG = {
             'an-alias': {
-                'entity_id': 'http://test-idp'
+                'entity_id': 'http://test-idp',
             }
         }
 


### PR DESCRIPTION
AppStream needs the `User.user_id` field whilst Quicksight should use the `User.email` field