### PR TITLE
Add user merge admin action

### DIFF
--- a/sso/templates/admin/merge_users_confirmation.html
+++ b/sso/templates/admin/merge_users_confirmation.html
@@ -1,0 +1,60 @@
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls static %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {% trans 'Merge users' %}
+</div>
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation merge-selected-confirmation{% endblock %}
+
+{% block content %}
+{% if perms_lacking %}
+    <p>{% blocktrans %}You do not have sufficient permissions to merge users.{% endblocktrans %}</p>
+{% else %}
+    <p>{% blocktrans %}Select the user entry to retain - the other users will be merged into this user.{% endblocktrans %}</p>
+    <h2>{% trans "Users" %}</h2>
+
+    <form method="post">{% csrf_token %}
+    <table>
+        <tr>
+            <td>Choose Primary</td>
+            <td>email user id</td>
+            <td>email</td>
+            <td>last accessed</td>
+            <td>is active?</td>
+            <td>additional emails</td>
+        </tr>
+    {% for obj in queryset %}
+        <tr>
+          <td style="text-align: center"><input type="radio" name="merge-primary-id" value="{{ obj.pk }}" required></td>
+          <td>{{ obj.email_user_id }}</td>
+          <td>{{ obj.email }}</td>
+          <td>{{ obj.last_accessed|default_if_none:"" }}</td>
+          <td>{{ obj.is_active }}</td>
+          <td>{{ obj.get_extra_emails|join:", " }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+    <div>
+    {% for obj in queryset %}
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="merge_users">
+    <input type="hidden" name="post" value="yes">
+    <input type="submit" value="{% trans 'Merge users' %}">
+    <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
+    </div>
+    </form>
+{% endif %}
+{% endblock %}

--- a/sso/tests/test_admin.py
+++ b/sso/tests/test_admin.py
@@ -2,11 +2,13 @@ import re
 
 import pytest
 
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.admin.models import LogEntry
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.shortcuts import reverse
 
-from sso.user.admin_views import ShowUserPermissionsView
 from sso.user.admin import UserAdmin
+from sso.user.admin_views import ShowUserPermissionsView
 
 from .factories.oauth import ApplicationFactory
 from .factories.user import UserFactory
@@ -15,6 +17,8 @@ from .factories.user import UserFactory
 pytestmark = [
     pytest.mark.django_db
 ]
+
+User = get_user_model()
 
 
 class TestShowUserPermissionsView:
@@ -115,3 +119,135 @@ class TestAdminSSOLogin:
 
         assert response.status_code == 302
         assert response.url == reverse('saml2_login_start') + '?next=/admin/'
+
+
+@pytest.fixture
+def auth_client(client):
+    admin_user = UserFactory(is_staff=True, is_superuser=True)
+    client.force_login(admin_user)
+
+    return client
+
+
+class TestMergeAction:
+    def test_require_more_than_one_user(self, auth_client):
+        """If only one checkbox is selected on the user's page then display an error, as we need at least
+        two users to merge"""
+
+        user = UserFactory()
+        response = auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', 'select_across': 0, 'index': 0, '_selected_action': [user.id]},
+            follow=True
+        )
+
+        assert b'<li class="error">You need to select at least two records to use the merge function</li>' in response.content  # noqa: E501
+
+    def test_view_merge_form(self, auth_client):
+
+        ids = [user.id for user in UserFactory.create_batch(2)]
+        response = auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', 'select_across': 0, 'index': 0, '_selected_action': ids},
+            follow=True
+        )
+
+        content = response.content.decode('utf-8')
+
+        matches = re.findall(r'<input type="hidden" name="_selected_action" value="\d*">', content)
+        assert set(matches) == set([f'<input type="hidden" name="_selected_action" value="{id}">' for id in ids])
+
+        matches = re.findall(r'<input type="radio" name="merge-primary-id" value="\d*" required>', content)
+        assert set(matches) == \
+            set([f'<input type="radio" name="merge-primary-id" value="{id}" required>' for id in ids])
+
+    def test_error_if_primary_user_not_selected(self, auth_client):
+        """Check that an error is displayed if the user fails to select the primary user to merge into"""
+
+        ids = [user.id for user in UserFactory.create_batch(2)]
+        response = auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', '_selected_action': ids, 'post': 'yes'},
+            follow=True
+        )
+
+        assert b'<li class="error">Specify a primary record.</li>' in response.content
+
+    def test_successful_merge(self, auth_client):
+
+        primary_user = UserFactory(email='primary@email.com', email_list=['primary2@email.com'])
+        user2 = UserFactory(email='user2_1@email.com', email_list=['user2_2@email.com'])
+        user3 = UserFactory(email='user3_1@email.com', email_list=['user3_2@email.com', 'user3_3@email.com'])
+
+        ids = [primary_user.id, user2.id, user3.id]
+
+        auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', '_selected_action': ids, 'merge-primary-id': primary_user.pk, 'post': 'yes'},
+            follow=True
+        )
+
+        assert User.objects.filter(pk=primary_user.pk).exists()
+        assert not User.objects.filter(pk__in=[user2.pk, user3.pk]).exists()
+
+        all_emails = set([email.email for user in [primary_user, user2, user3] for email in user.emails.all()])
+
+        primary_user.refresh_from_db()
+        primary_emails = set(primary_user.emails.all().values_list('email', flat=True))
+
+        assert primary_emails == all_emails
+
+    def test_deleted_users_are_logged(self, auth_client):
+
+        primary_user = UserFactory(email='primary@email.com')
+        user2 = UserFactory(email='user2_1@email.com')
+
+        ids = [primary_user.id, user2.id]
+
+        assert LogEntry.objects.count() == 0
+
+        auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', '_selected_action': ids, 'merge-primary-id': primary_user.pk, 'post': 'yes'},
+            follow=True
+        )
+
+        assert LogEntry.objects.count() == 1
+        log = LogEntry.objects.first()
+
+        assert log.is_deletion()
+        assert log.object_repr == f'User(id={user2.pk}, user_id={user2.user_id}, email_user_id={user2.email_user_id})'
+        assert log.change_message == f'merged into {primary_user.user_id}'
+
+    @pytest.mark.parametrize('perms,expected_status', [
+        (
+            [], 403
+        ),
+        (
+            ['change_user'], 403
+        ),
+        (
+            ['delete_user'], 403
+        ),
+        (
+            ['delete_user', 'change_user'], 200
+        ),
+    ])
+    def test_requires_change_and_delete_permissions(self, perms, expected_status, auth_client):
+        assert User.objects.count() == 1
+        user = User.objects.first()
+
+        user.is_superuser = False
+        user.save()
+
+        for perm in perms:
+            user.user_permissions.add(Permission.objects.get(codename=perm))
+
+        ids = [user.id for user in UserFactory.create_batch(2)]
+        response = auth_client.post(
+            reverse('admin:user_user_changelist'),
+            {'action': 'merge_users', '_selected_action': ids, 'merge-primary-id': ids[0], 'post': 'yes'},
+            follow=True
+        )
+
+        assert response.status_code == expected_status

--- a/sso/tests/test_user.py
+++ b/sso/tests/test_user.py
@@ -561,6 +561,12 @@ class TestUser:
 
         assert current_id == user.email_user_id
 
+    def test_get_extra_emails(self):
+
+        user = UserFactory(email='primar@test.com', email_list=['email1@test.com', 'email2@test.com'])
+
+        assert set(user.get_extra_emails()) == set(['email1@test.com', 'email2@test.com'])
+
 
 class TestAccessProfile:
     def test_is_allowed_true(self):

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -230,6 +230,9 @@ class User(AbstractBaseUser, PermissionsMixin):
         """Django method that must be implemented"""
         return self.get_full_name()
 
+    def get_extra_emails(self):
+        return list(self.emails.exclude(email=self.email).values_list('email', flat=True))
+
     def _is_allowed_email(self, application):
         """Returns True if any of the user's emails are whitelisted in the OAuth2 app"""
 


### PR DESCRIPTION
This feature allows administrators to merge multiple user accounts into a single user whilst retaining all email addresses.

