### PR TITLE
Add application permissions to introspection response

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: "postgres:10"
     restart: always
     environment:
-      - POSTGRESS_PASSWORD=does-it-really-matter
+      - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
       - POSTGRES_DB=staff-sso
     volumes:

--- a/sso/tests/factories/saml.py
+++ b/sso/tests/factories/saml.py
@@ -1,10 +1,12 @@
 import factory
 
+from django.utils.text import slugify
 from sso.samlidp.models import SamlApplication
 
 
 class SamlApplicationFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f'saml application {n+1}')
+    slug = factory.LazyAttribute(lambda o: slugify(o.name))
     start_url = factory.Sequence(lambda n: f'https://www.site{n+1}')
     entity_id = factory.Sequence(lambda n: f'entity_id_{n+1}')
     allowed_ips = ''

--- a/sso/tests/test_user_api.py
+++ b/sso/tests/test_user_api.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from collections import defaultdict
 
 import pytest
 from django.urls import reverse_lazy
@@ -8,7 +9,7 @@ from sso.oauth2.models import Application
 
 from .factories.oauth import AccessTokenFactory, ApplicationFactory
 from .factories.saml import SamlApplicationFactory
-from .factories.user import GroupFactory, UserFactory, AccessProfileFactory
+from .factories.user import GroupFactory, UserFactory, AccessProfileFactory, ApplicationPermissionFactory
 
 pytestmark = [
     pytest.mark.django_db
@@ -74,7 +75,8 @@ class TestAPIGetUserMe:
                     'url': application.start_url
                 }
             ],
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
     def test_fails_with_invalid_token(self, api_client):
@@ -283,7 +285,8 @@ class TestApiUserIntrospect:
                     'url': application.start_url
                 }
             ],
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
     def test_with_valid_token_and_email_alias(self, api_client):
@@ -316,7 +319,8 @@ class TestApiUserIntrospect:
                     'url': application.start_url
                 }
             ],
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
     def test_with_valid_token_and_access_profile(self, api_client):
@@ -351,7 +355,8 @@ class TestApiUserIntrospect:
                     'url': application.start_url
                 }
             ],
-            'access_profiles': [ap.slug]
+            'access_profiles': [ap.slug],
+            'application_permissions': [],
         }
 
     def test_with_valid_token_and_permitted_applications(self, api_client):
@@ -385,7 +390,49 @@ class TestApiUserIntrospect:
             'contact_email': '',
             'groups': [],
             'permitted_applications': permitted_applications,
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
+        }
+
+    def test_with_valid_token_and_application_permissions(self, api_client):
+        user, token = get_oauth_token(scope='introspection')
+
+        app = ApplicationFactory(users=[user])
+        saml_app = SamlApplicationFactory(entity_id='an_entity_id', enabled=True)
+
+        ap = AccessProfileFactory(saml_apps_list=[saml_app])
+        user.access_profiles.add(ap)
+
+        user.emails.create(email='test@aaa.com')
+        user.emails.create(email='test@bbb.com')
+
+        ap1 = ApplicationPermissionFactory(oauth2_application=app)
+        ap2 = ApplicationPermissionFactory(oauth2_application=app)
+        saml_ap1 = ApplicationPermissionFactory(saml2_application=saml_app)
+        saml_ap2 = ApplicationPermissionFactory(saml2_application=saml_app)
+        user.application_permissions.add(ap1)
+        user.application_permissions.add(ap2)
+        user.application_permissions.add(saml_ap1)
+        user.application_permissions.add(saml_ap2)
+
+        application_permissions = [permission.full_permission_name() for permission in user.application_permissions.all()]
+
+        api_client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        response = api_client.get(self.GET_USER_INTROSPECT_URL + '?email=test@aaa.com')
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'email': 'user1@example.com',
+            'user_id': str(user.user_id),
+            'email_user_id': user.email_user_id,
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'related_emails': ['test@aaa.com', 'test@bbb.com'],
+            'contact_email': '',
+            'groups': [],
+            'permitted_applications': user.get_permitted_applications(include_non_public=True),
+            'access_profiles': [ap.slug],
+            'application_permissions': application_permissions,
         }
 
     def test_with_user_id(self, api_client):
@@ -415,7 +462,8 @@ class TestApiUserIntrospect:
             'contact_email': '',
             'groups': [],
             'permitted_applications': permitted_applications,
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
     def test_with_email_user_id(self, api_client):
@@ -445,7 +493,8 @@ class TestApiUserIntrospect:
             'contact_email': '',
             'groups': [],
             'permitted_applications': permitted_applications,
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
     def test_requires_email_or_user_id_or_email_user_id(self, api_client):
@@ -517,7 +566,8 @@ class TestApiUserIntrospect:
                     'url': application.start_url
                 }
             ],
-            'access_profiles': []
+            'access_profiles': [],
+            'application_permissions': [],
         }
 
 

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -69,6 +69,9 @@ class ApplicationPermission(models.Model):
 
         return app_key
 
+    def full_permission_name(self):
+        return f'{self.application_name()}: {self.permission}'
+
     def __str__(self):
         return f'{self.application_name()} - {self.permission}'
 

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import Group
+from django.db.models import Q
 from rest_framework import serializers
 
 from .models import User

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -31,7 +31,8 @@ class UserSerializer(serializers.ModelSerializer):
             'contact_email': obj.contact_email,
             'groups': [],
             'permitted_applications': obj.get_permitted_applications(include_non_public=True),
-            'access_profiles': [profile.slug for profile in obj.access_profiles.all()]
+            'access_profiles': [profile.slug for profile in obj.access_profiles.all()],
+            'application_permissions': [permission.full_permission_name() for permission in obj.application_permissions.all()],
         }
 
 

--- a/sso/user/views.py
+++ b/sso/user/views.py
@@ -13,7 +13,8 @@ from rest_framework.response import Response
 
 from sso.oauth2.models import Application as OAuthApplication
 from .serializers import (
-    UserSerializer,
+    UserIntrospectionSerializer,
+    UserMeSerializer,
     UserParamSerializer,
     UserDetailsSerializer,
     UserListSerializer
@@ -24,7 +25,7 @@ from .autocomplete import AutocompleteFilter
 
 class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     permission_classes = [permissions.IsAuthenticated]
-    serializer_class = UserSerializer
+    serializer_class = UserMeSerializer
 
     def get_object(self):
         return self.request.user
@@ -55,7 +56,7 @@ class UserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 class UserIntrospectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     permission_classes = [permissions.IsAuthenticated, TokenHasScope]
     required_scopes = ['introspection']
-    serializer_class = UserSerializer
+    serializer_class = UserIntrospectionSerializer
 
     def retrieve(self, request):
 
@@ -77,7 +78,7 @@ class UserIntrospectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
             # The user does not have permission to access this OAuth2 application
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = UserSerializer(selected_user, context=dict(request=request))
+        serializer = UserIntrospectionSerializer(selected_user, context=dict(request=request))
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
This adds `current_application_permissions` key in the introspection endpoint response and `application_permissions` in the me endpoint response..

The `/me` endpoint returns a list of all application permissions available to the user.

Permissions are formatted in following format: <application type>: <application slug/key>: <application permission>

For example: 
```
{
  ...
  "application_permissions": ["oauth2: another-app: view.something", "saml2: test-app: view.table", "saml2: test-app: edit.table", ...],
}
```
I have not used the string representation, because I thought it will be easy to split the permission string by `: ` and have three parts to look at. 

The `/introspect` endpoint returns a list of current application permissions:

For example: 
```
{
  ...
  "current_application_permissions": ["view.table", "edit.table", ...],
}
```
