### PR TITLE
Add active status to Activity Stream endpoint

### DIFF
--- a/sso/core/views.py
+++ b/sso/core/views.py
@@ -145,6 +145,7 @@ def activity_stream(request):
                             include_non_public=True,
                             get_default_access_allowed_apps=lambda: default_access_apps)
                     ],
+                    'dit:StaffSSO:User:status': 'active' if user.is_active else 'inactive',
                     'dit:firstName': user.first_name,
                     'dit:lastName': user.last_name,
                     'dit:emailAddress': without_duplicates(


### PR DESCRIPTION
This is to support more queries in Data Workspace. Leaning away from the boolean to allow more statuses down the line, and to make it easier to understand the field without having to look at the key.