### PR TITLE
Remove new saml idp paths from metadata

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -418,12 +418,13 @@ SAML_IDP_CONFIG = {
             "endpoints": {
                 "single_sign_on_service": [
                     # new post binding path
-                    (os.path.join(BASE_URL, "idp/sso/post/"), saml2.BINDING_HTTP_POST),
-                    (
-                        os.path.join(BASE_URL, "idp/sso/redirect/"),
-                        saml2.BINDING_HTTP_REDIRECT,
-                    ),
+                    # (os.path.join(BASE_URL, "idp/sso/post/"), saml2.BINDING_HTTP_POST),
+                    # (
+                    #     os.path.join(BASE_URL, "idp/sso/redirect/"),
+                    #     saml2.BINDING_HTTP_REDIRECT,
+                    # ),
                     # legacy paths - can be removed when all SPs have updated IdP metadata
+                    # with new paths
                     (os.path.join(BASE_URL, "idp/sso/post"), saml2.BINDING_HTTP_POST),
                     (
                         os.path.join(BASE_URL, "idp/sso/redirect"),


### PR DESCRIPTION
The new paths with trailing /'s cause ELK to die with:

"type":"exception","reason":"Found multiple locations for binding [urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect] in descriptor [null]

Since ELK is the only app that dynamically pulls metadata, we're temporarily rolling back to legacy idp urls (without slashes).